### PR TITLE
fix: lending withdraw

### DIFF
--- a/contracts/Mocks/DummyLendingService.sol
+++ b/contracts/Mocks/DummyLendingService.sol
@@ -27,14 +27,13 @@ contract DummyLendingService is LendingService {
         emit Lend(msg.sender, address(0), msg.value);
     }
 
-    function withdraw(uint256 amount) public override {
-        if (amount == 0) {
-            revert InvalidAmount(amount);
-        }
+    function withdraw() public override {
+        (uint256 deposited, uint256 interest) = _acmeLending.getBalance(
+            msg.sender
+        );
+        _acmeLending.withdraw(deposited, msg.sender);
 
-        _acmeLending.withdraw(amount, msg.sender);
-
-        emit Withdraw(msg.sender, address(0), amount);
+        emit Withdraw(msg.sender, address(0), deposited + interest);
     }
 
     function getBalance() public view override returns (uint256) {

--- a/contracts/Services/LendingService.sol
+++ b/contracts/Services/LendingService.sol
@@ -42,7 +42,7 @@ abstract contract LendingService is Service {
         payable
         virtual;
 
-    function withdraw(uint256 amount) public virtual;
+    function withdraw() public virtual;
 
     function getBalance() public virtual returns (uint256);
 

--- a/test/services/DummyLendingService.spec.ts
+++ b/test/services/DummyLendingService.spec.ts
@@ -9,6 +9,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { DummyLendingService } from 'typechain-types/contracts/Mocks';
 
 describe('DummyLendingService', () => {
+  const INTEREST_PER_100_BLOCKS = 10;
   async function deployDummyLendingServiceFixture() {
     const [owner] = await ethers.getSigners();
 
@@ -100,9 +101,15 @@ describe('DummyLendingService', () => {
     // Fast forward 100 blocks
     await network.provider.send('hardhat_mine', ['0x' + (100).toString(16)]);
 
-    await expect(dummyLendingService.withdraw(RBTC_DEPOSIT))
+    const FAST_FORWARD_BLOCKS = 101;
+    const ACC_INTEREST = RBTC_DEPOSIT.mul(FAST_FORWARD_BLOCKS)
+      .mul(INTEREST_PER_100_BLOCKS)
+      .div(100 * 100);
+    const totalBalance = ACC_INTEREST.add(RBTC_DEPOSIT);
+
+    await expect(dummyLendingService.withdraw())
       .to.emit(dummyLendingService, 'Withdraw')
-      .withArgs(owner.address, currency, RBTC_DEPOSIT);
+      .withArgs(owner.address, currency, totalBalance);
   });
 
   it('should return "0" when getBalance is called', async () => {


### PR DESCRIPTION
Issue: the total balance calculations have discrepancies since it is block based and a transaction is always one block ahead.
Fix: we disable parcial balance withdrawals and only allow total balance withdraw. 