### PR TITLE
chore: remove onlyOwner modifer from addListing

### DIFF
--- a/contracts/services/Service.sol
+++ b/contracts/services/Service.sol
@@ -17,7 +17,6 @@ abstract contract Service is Ownable, IService {
     function addListing(ServiceListing memory listing)
         public
         override
-        onlyOwner
         returns (uint256)
     {
         //todo: check mandatory values.


### PR DESCRIPTION
The change in this PR is to remove the only owner modifier for add new listings thereby allowing any service provider access as per the updated requirements of the gateway.