### PR TITLE
fix(RIFGateway): provider verification

### DIFF
--- a/contracts/gateway/IRIFGateway.sol
+++ b/contracts/gateway/IRIFGateway.sol
@@ -13,7 +13,6 @@ interface IRIFGateway {
     error ProviderAlreadyValidated(address provider);
     error ValidationNotRequested(address provider);
 
-
     event ServiceAdded(address provider, address service);
     event ValidationRequested(address provider);
     event ServiceValidated(address provider, address service);

--- a/contracts/gateway/RIFGateway.sol
+++ b/contracts/gateway/RIFGateway.sol
@@ -77,7 +77,8 @@ contract RIFGateway is Ownable, SubscriptionReporter, IRIFGateway {
     }
 
     function validateProvider(address provider) external override onlyOwner {
-        if (_providerIndexes[provider] == 0) revert ValidationNotRequested(provider);
+        if (_providerIndexes[provider] == 0)
+            revert ValidationNotRequested(provider);
         _checkIfProviderIsAlreadyValidated(provider);
 
         _providers[_providerIndexes[provider] - 1].validated = true;

--- a/test/services/RIFGateway.spec.ts
+++ b/test/services/RIFGateway.spec.ts
@@ -168,7 +168,6 @@ describe('RIF Gateway', () => {
           .withArgs(signer.address);
       });
     });
-
     describe.only('validateProvider', () => {
       it('should validate a provider when no services have been added by the provider', async () => {
         await (await rifGateway.requestValidation(signer.address)).wait();


### PR DESCRIPTION
- Removes the need of having to add a service before a RIF owner can validate a provider (in `validateProvider()`)
- Removes the need of having to add a service before a provider can request validation (in `requestValidation()`)
- Updates and organize unit tests.

***TODO***: Consider to re evaluate if the flow for `request validation` and `validate provider` can be improved, consider the following:

- If a provider request validation, there isn't a mechanism to prevent the same provider to request validation again. The only action taken is emitting an event and that's it. We should validate this (perhaps adding another state like `pendingValidation` and check against that.

