### PR TITLE
feat: only one AccessControl for RIfGateway and FeeManager

### DIFF
--- a/contracts/access/GatewayAccessControl.sol
+++ b/contracts/access/GatewayAccessControl.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.16;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./IGatewayAccessControl.sol";
+import "./Roles.sol";
 
 /**
  * @title GatewayAccessControl

--- a/contracts/access/GatewayAccessControl.sol
+++ b/contracts/access/GatewayAccessControl.sol
@@ -3,12 +3,7 @@ pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-bytes32 constant OWNER = keccak256("OWNER");
-bytes32 constant LOW_LEVEL_OPERATOR = keccak256("LOW_LEVEL_OPERATOR");
-bytes32 constant HIGH_LEVEL_OPERATOR = keccak256("HIGH_LEVEL_OPERATOR");
-bytes32 constant FINANCIAL_OWNER = keccak256("FINANCIAL_OWNER");
-bytes32 constant FINANCIAL_OPERATOR = keccak256("FINANCIAL_OPERATOR");
+import "./IGatewayAccessControl.sol";
 
 /**
  * @title GatewayAccessControl
@@ -16,7 +11,7 @@ bytes32 constant FINANCIAL_OPERATOR = keccak256("FINANCIAL_OPERATOR");
  * @dev The main contract that that handles the role and their access within the gateway.
  * This roles had been defined by the Security team and each address should from a multisig wallet.
  */
-contract GatewayAccessControl is AccessControl, Ownable {
+contract GatewayAccessControl is IGatewayAccessControl, AccessControl, Ownable {
     /**
      * @notice Grants the default admin role OWNER to the deployer.
      * @dev The default admin role is keccak256("OWNER"), which means that
@@ -35,8 +30,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Grants OWNER role and transfers ownership of the contract to the given address.
-     * @param newOwner address to be grant OWNER role and transfer ownership.
+     * @inheritdoc IGatewayAccessControl
      */
     function changeOwner(address newOwner) public onlyRole(OWNER) {
         grantRole(OWNER, newOwner);
@@ -45,25 +39,21 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Checks if the given address has OWNER role.
-     * @param owner address to check.
-     * @return bool true if the given address has OWNER role.
+     * @inheritdoc IGatewayAccessControl
      */
     function isOwner(address owner) public view returns (bool) {
         return hasRole(OWNER, owner);
     }
 
     /**
-     * @notice Grants LOW_LEVEL_OPERATOR role to the given address.
-     * @param lowOperator address to be grant LOW_LEVEL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function addLowLevelOperator(address lowOperator) public onlyRole(OWNER) {
         grantRole(LOW_LEVEL_OPERATOR, lowOperator);
     }
 
     /**
-     * @notice Revokes LOW_LEVEL_OPERATOR role to the given address.
-     * @param lowOperator address to be revoke LOW_LEVEL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function removeLowLevelOperator(address lowOperator)
         public
@@ -73,9 +63,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Checks if the given address has LOW_LEVEL_OPERATOR role.
-     * @param lowOperator address to check.
-     * @return bool true if the given address has LOW_LEVEL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function isLowLevelOperator(address lowOperator)
         public
@@ -86,16 +74,14 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Grants HIGH_LEVEL_OPERATOR role to the given address.
-     * @param highOperator address to be grant HIGH_LEVEL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function addHighLevelOperator(address highOperator) public onlyRole(OWNER) {
         grantRole(HIGH_LEVEL_OPERATOR, highOperator);
     }
 
     /**
-     * @notice Revokes HIGH_LEVEL_OPERATOR role to the given address.
-     * @param highOperator address to be revoke HIGH_LEVEL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function removeHighLevelOperator(address highOperator)
         public
@@ -105,9 +91,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Checks if the given address has HIGH_LEVEL_OPERATOR role.
-     * @param highOperator address to check.
-     * @return bool true if the given address has HIGH_LEVEL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function isHighLevelOperator(address highOperator)
         public
@@ -118,16 +102,14 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Grants FINANCIAL_OWNER role to the given address.
-     * @param financialOwner address to be grant FINANCIAL_OWNER role.
+     * @inheritdoc IGatewayAccessControl
      */
     function addFinancialOwner(address financialOwner) public onlyRole(OWNER) {
         grantRole(FINANCIAL_OWNER, financialOwner);
     }
 
     /**
-     * @notice Revokes FINANCIAL_OWNER role to the given address.
-     * @param financialOwner address to be revoke FINANCIAL_OWNER role.
+     * @inheritdoc IGatewayAccessControl
      */
     function removeFinancialOwner(address financialOwner)
         public
@@ -137,9 +119,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Checks if the given address has FINANCIAL_OWNER role.
-     * @param financialOwner address to check.
-     * @return bool true if the given address has FINANCIAL_OWNER role.
+     * @inheritdoc IGatewayAccessControl
      */
     function isFinancialOwner(address financialOwner)
         public
@@ -150,8 +130,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Grants FINANCIAL_OPERATOR role to the given address.
-     * @param financialOperator address to be grant FINANCIAL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function addFinancialOperator(address financialOperator)
         public
@@ -161,8 +140,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Revokes FINANCIAL_OPERATOR role to the given address.
-     * @param financialOperator address to be revoke FINANCIAL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function removeFinancialOperator(address financialOperator)
         public
@@ -172,9 +150,7 @@ contract GatewayAccessControl is AccessControl, Ownable {
     }
 
     /**
-     * @notice Checks if the given address has FINANCIAL_OPERATOR role.
-     * @param financialOperator address to check.
-     * @return bool true if the given address has FINANCIAL_OPERATOR role.
+     * @inheritdoc IGatewayAccessControl
      */
     function isFinancialOperator(address financialOperator)
         public

--- a/contracts/access/IGatewayAccessControl.sol
+++ b/contracts/access/IGatewayAccessControl.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
-bytes32 constant OWNER = keccak256("OWNER");
-bytes32 constant LOW_LEVEL_OPERATOR = keccak256("LOW_LEVEL_OPERATOR");
-bytes32 constant HIGH_LEVEL_OPERATOR = keccak256("HIGH_LEVEL_OPERATOR");
-bytes32 constant FINANCIAL_OWNER = keccak256("FINANCIAL_OWNER");
-bytes32 constant FINANCIAL_OPERATOR = keccak256("FINANCIAL_OPERATOR");
-
 /**
  * @title IGatewayAccessControl
  * @author RIF Protocols Team

--- a/contracts/access/IGatewayAccessControl.sol
+++ b/contracts/access/IGatewayAccessControl.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+bytes32 constant OWNER = keccak256("OWNER");
+bytes32 constant LOW_LEVEL_OPERATOR = keccak256("LOW_LEVEL_OPERATOR");
+bytes32 constant HIGH_LEVEL_OPERATOR = keccak256("HIGH_LEVEL_OPERATOR");
+bytes32 constant FINANCIAL_OWNER = keccak256("FINANCIAL_OWNER");
+bytes32 constant FINANCIAL_OPERATOR = keccak256("FINANCIAL_OPERATOR");
+
+/**
+ * @title IGatewayAccessControl
+ * @author RIF Protocols Team
+ * @dev The main contract that that handles the role and their access within the gateway.
+ * This roles had been defined by the Security team and each address should from a multisig wallet.
+ */
+interface IGatewayAccessControl {
+    /**
+     * @notice Grants OWNER role and transfers ownership of the contract to the given address.
+     * @param newOwner address to be grant OWNER role and transfer ownership.
+     */
+    function changeOwner(address newOwner) external;
+
+    /**
+     * @notice Checks if the given address has OWNER role.
+     * @param owner address to check.
+     * @return bool true if the given address has OWNER role.
+     */
+    function isOwner(address owner) external view returns (bool);
+
+    /**
+     * @notice Grants LOW_LEVEL_OPERATOR role to the given address.
+     * @param lowOperator address to be grant LOW_LEVEL_OPERATOR role.
+     */
+    function addLowLevelOperator(address lowOperator) external;
+
+    /**
+     * @notice Revokes LOW_LEVEL_OPERATOR role to the given address.
+     * @param lowOperator address to be revoke LOW_LEVEL_OPERATOR role.
+     */
+    function removeLowLevelOperator(address lowOperator) external;
+
+    /**
+     * @notice Checks if the given address has LOW_LEVEL_OPERATOR role.
+     * @param lowOperator address to check.
+     * @return bool true if the given address has LOW_LEVEL_OPERATOR role.
+     */
+    function isLowLevelOperator(address lowOperator)
+        external
+        view
+        returns (bool);
+
+    /**
+     * @notice Grants HIGH_LEVEL_OPERATOR role to the given address.
+     * @param highOperator address to be grant HIGH_LEVEL_OPERATOR role.
+     */
+    function addHighLevelOperator(address highOperator) external;
+
+    /**
+     * @notice Revokes HIGH_LEVEL_OPERATOR role to the given address.
+     * @param highOperator address to be revoke HIGH_LEVEL_OPERATOR role.
+     */
+    function removeHighLevelOperator(address highOperator) external;
+
+    /**
+     * @notice Checks if the given address has HIGH_LEVEL_OPERATOR role.
+     * @param highOperator address to check.
+     * @return bool true if the given address has HIGH_LEVEL_OPERATOR role.
+     */
+    function isHighLevelOperator(address highOperator)
+        external
+        view
+        returns (bool);
+
+    /**
+     * @notice Grants FINANCIAL_OWNER role to the given address.
+     * @param financialOwner address to be grant FINANCIAL_OWNER role.
+     */
+    function addFinancialOwner(address financialOwner) external;
+
+    /**
+     * @notice Revokes FINANCIAL_OWNER role to the given address.
+     * @param financialOwner address to be revoke FINANCIAL_OWNER role.
+     */
+    function removeFinancialOwner(address financialOwner) external;
+
+    /**
+     * @notice Checks if the given address has FINANCIAL_OWNER role.
+     * @param financialOwner address to check.
+     * @return bool true if the given address has FINANCIAL_OWNER role.
+     */
+    function isFinancialOwner(address financialOwner)
+        external
+        view
+        returns (bool);
+
+    /**
+     * @notice Grants FINANCIAL_OPERATOR role to the given address.
+     * @param financialOperator address to be grant FINANCIAL_OPERATOR role.
+     */
+    function addFinancialOperator(address financialOperator) external;
+
+    /**
+     * @notice Revokes FINANCIAL_OPERATOR role to the given address.
+     * @param financialOperator address to be revoke FINANCIAL_OPERATOR role.
+     */
+    function removeFinancialOperator(address financialOperator) external;
+
+    /**
+     * @notice Checks if the given address has FINANCIAL_OPERATOR role.
+     * @param financialOperator address to check.
+     * @return bool true if the given address has FINANCIAL_OPERATOR role.
+     */
+    function isFinancialOperator(address financialOperator)
+        external
+        view
+        returns (bool);
+}

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+bytes32 constant OWNER = keccak256("OWNER");
+bytes32 constant LOW_LEVEL_OPERATOR = keccak256("LOW_LEVEL_OPERATOR");
+bytes32 constant HIGH_LEVEL_OPERATOR = keccak256("HIGH_LEVEL_OPERATOR");
+bytes32 constant FINANCIAL_OWNER = keccak256("FINANCIAL_OWNER");
+bytes32 constant FINANCIAL_OPERATOR = keccak256("FINANCIAL_OPERATOR");

--- a/contracts/feeManager/FeeManager.sol
+++ b/contracts/feeManager/FeeManager.sol
@@ -260,12 +260,12 @@ contract FeeManager is IFeeManager, Ownable {
      * @inheritdoc IFeeManager
      */
     function setRIFGateway(IRIFGateway rifGateway) public override {
-        _rifGateway = rifGateway;
         require(
-            GatewayAccessControl(IRIFGateway(_rifGateway).getAccessControl())
+            GatewayAccessControl(IRIFGateway(rifGateway).getAccessControl())
                 .isFinancialOwner(msg.sender),
             "Not FINANCIAL_OWNER role"
         );
+        _rifGateway = rifGateway;
     }
 
     /**

--- a/contracts/feeManager/FeeManager.sol
+++ b/contracts/feeManager/FeeManager.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import {IFeeManager} from "./IFeeManager.sol";
 import "../access/GatewayAccessControl.sol";
 import "../gateway/IRIFGateway.sol";
-import "hardhat/console.sol";
 
 /* solhint-disable avoid-low-level-calls */
 

--- a/contracts/feeManager/IFeeManager.sol
+++ b/contracts/feeManager/IFeeManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
+import "../gateway/IRIFGateway.sol";
+
 /**
  * @title Fee Manager Interface
  * @notice Handles all fee distribution across the RIF Gateway
@@ -93,4 +95,22 @@ interface IFeeManager {
      * @param debtor the address of debtor
      */
     function payInBehalfOf(address debtor) external payable;
+
+    /**
+     * @notice Returns the address of the rif gateway fees owner
+     * @return The address of the gateway fees owner
+     */
+    function getGatewayFeesOwner() external view returns (address);
+
+    /**
+     * @notice Sets the address of the rif gateway contract
+     * @param rifGateway The address of the rif gateway contract
+     */
+    function setRIFGateway(IRIFGateway rifGateway) external;
+
+    /**
+     * @notice Gets the address of the rif gateway contract
+     * @return The address of the rif gateway contract
+     */
+    function getRIFGateway() external view returns (IRIFGateway);
 }

--- a/contracts/gateway/IRIFGateway.sol
+++ b/contracts/gateway/IRIFGateway.sol
@@ -75,4 +75,10 @@ interface IRIFGateway {
      * @param service The address of the service to be removed
      */
     function removeService(Service service) external;
+
+    /**
+     * @notice Returns the address of the access control contract
+     * @return The address of the access control contract
+     */
+    function getAccessControl() external view returns (address);
 }

--- a/contracts/gateway/IRIFGateway.sol
+++ b/contracts/gateway/IRIFGateway.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.16;
 
 import "../services/Service.sol";
 import {Provider} from "../services/ServiceData.sol";
+import "../access/GatewayAccessControl.sol";
 
 /**
  * @title RIF Gateway interface
@@ -80,5 +81,5 @@ interface IRIFGateway {
      * @notice Returns the address of the access control contract
      * @return The address of the access control contract
      */
-    function getAccessControl() external view returns (address);
+    function getAccessControl() external view returns (GatewayAccessControl);
 }

--- a/contracts/gateway/RIFGateway.sol
+++ b/contracts/gateway/RIFGateway.sol
@@ -7,6 +7,7 @@ import "./SubscriptionReporter.sol";
 import {Provider} from "../services/ServiceData.sol";
 import "../services/Service.sol";
 import "../services/ServiceTypeManager.sol";
+import "../access/GatewayAccessControl.sol";
 import "../access/IGatewayAccessControl.sol";
 
 /**
@@ -18,7 +19,7 @@ contract RIFGateway is Ownable, SubscriptionReporter, IRIFGateway {
     Provider[] private _providers;
     mapping(address => uint256) private _providerIndexes; // indexes from 1, 0 used to verify not duplication
     ServiceTypeManager private _serviceTypeManager;
-    IGatewayAccessControl private _accessControl;
+    GatewayAccessControl private _accessControl;
     Service[] private _allServices;
     mapping(address => bool) private _uniqueServices;
 
@@ -26,7 +27,7 @@ contract RIFGateway is Ownable, SubscriptionReporter, IRIFGateway {
 
     constructor(
         ServiceTypeManager stm,
-        IGatewayAccessControl gatewayAccessControl
+        GatewayAccessControl gatewayAccessControl
     ) {
         _serviceTypeManager = stm;
         _accessControl = gatewayAccessControl;
@@ -101,7 +102,7 @@ contract RIFGateway is Ownable, SubscriptionReporter, IRIFGateway {
             IGatewayAccessControl(_accessControl).isHighLevelOperator(
                 msg.sender
             ),
-            "Caller is not a financial operator"
+            "Not HIGH_LEVEL_OPERATOR role"
         );
         if (_providerIndexes[provider] == 0)
             revert ValidationNotRequested(provider);
@@ -167,7 +168,12 @@ contract RIFGateway is Ownable, SubscriptionReporter, IRIFGateway {
     /**
      * @inheritdoc IRIFGateway
      */
-    function getAccessControl() public view override returns (address) {
+    function getAccessControl()
+        public
+        view
+        override
+        returns (GatewayAccessControl)
+    {
         return _accessControl;
     }
 }

--- a/contracts/gateway/SubscriptionReporter.sol
+++ b/contracts/gateway/SubscriptionReporter.sol
@@ -14,7 +14,7 @@ abstract contract SubscriptionReporter is ISubscriptionReporter {
     IFeeManager public immutable feeManager;
 
     constructor() {
-        feeManager = new FeeManager(msg.sender);
+        feeManager = new FeeManager();
     }
 
     /**

--- a/test/services/RIFGateway.spec.ts
+++ b/test/services/RIFGateway.spec.ts
@@ -17,7 +17,7 @@ import {
   LENDING_SERVICE_INTERFACEID as LENDING_SERVICE_INTERFACE_ID,
 } from 'test/utils/interfaceIDs';
 
-describe.only('RIF Gateway', () => {
+describe('RIF Gateway', () => {
   let rifGateway: RIFGateway;
   let serviceTypeManager: ServiceTypeManager;
   let gatewayAccessControl: GatewayAccessControl;
@@ -93,24 +93,15 @@ describe.only('RIF Gateway', () => {
     newOwner = signers[3];
   });
 
-  describe('Roles', () => {
-    it('should set deployer as OWNER', async () => {
+  describe('Ownership', () => {
+    it('should transfer ownership to the given address', async () => {
       expect(await rifGateway.owner()).to.equal(signer.address);
-      expect(await rifGateway.getAccessControl().isOwner(signer.address)).to.be
-        .true;
-    });
-
-    it('should transfer OWNER and ownership to the given address', async () => {
-      expect(await rifGateway.owner()).to.equal(signer.address);
-      expect(await rifGateway.isOwner(signer.address)).to.be.true;
 
       await (
-        await rifGateway.connect(signer).changeOwner(newOwner.address)
+        await rifGateway.connect(signer).transferOwnership(newOwner.address)
       ).wait();
 
       expect(await rifGateway.owner()).to.equal(newOwner.address);
-      expect(await rifGateway.isOwner(newOwner.address)).to.be.true;
-      expect(await rifGateway.isOwner(signer.address)).to.be.false;
     });
   });
 
@@ -205,7 +196,7 @@ describe.only('RIF Gateway', () => {
     describe('validateProvider', () => {
       beforeEach(async () => {
         await (
-          await rifGateway
+          await gatewayAccessControl
             .connect(signer)
             .addHighLevelOperator(highLevelOperator.address)
         ).wait();

--- a/test/services/RIFGateway.spec.ts
+++ b/test/services/RIFGateway.spec.ts
@@ -3,6 +3,7 @@ import { ethers } from 'hardhat';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import {
   ServiceTypeManager,
+  GatewayAccessControl,
   TropykusLendingService__factory,
   TropykusLendingService,
   TropykusBorrowingService__factory,
@@ -16,9 +17,10 @@ import {
   LENDING_SERVICE_INTERFACEID as LENDING_SERVICE_INTERFACE_ID,
 } from 'test/utils/interfaceIDs';
 
-describe('RIF Gateway', () => {
+describe.only('RIF Gateway', () => {
   let rifGateway: RIFGateway;
   let serviceTypeManager: ServiceTypeManager;
+  let gatewayAccessControl: GatewayAccessControl;
   let signer: SignerWithAddress;
   let signers: SignerWithAddress[];
   let highLevelOperator: SignerWithAddress;
@@ -31,8 +33,11 @@ describe('RIF Gateway', () => {
     const signers = await ethers.getSigners();
     const signer = signers[0];
 
-    ({ RIFGateway: rifGateway, serviceTypeManager: serviceTypeManager } =
-      await deployRIFGateway(false));
+    ({
+      RIFGateway: rifGateway,
+      serviceTypeManager: serviceTypeManager,
+      gatewayAccessControl: gatewayAccessControl,
+    } = await deployRIFGateway(false));
 
     const tropykusLendingServiceFactory = (await ethers.getContractFactory(
       'TropykusLendingService'
@@ -67,6 +72,7 @@ describe('RIF Gateway', () => {
     return {
       rifGateway,
       serviceTypeManager,
+      gatewayAccessControl,
       tropykusLendingService,
       signer,
       signers,
@@ -78,6 +84,7 @@ describe('RIF Gateway', () => {
       rifGateway,
       serviceTypeManager,
       tropykusLendingService,
+      gatewayAccessControl,
       signer,
       signers,
     } = await loadFixture(initialFixture));
@@ -89,7 +96,8 @@ describe('RIF Gateway', () => {
   describe('Roles', () => {
     it('should set deployer as OWNER', async () => {
       expect(await rifGateway.owner()).to.equal(signer.address);
-      expect(await rifGateway.isOwner(signer.address)).to.be.true;
+      expect(await rifGateway.getAccessControl().isOwner(signer.address)).to.be
+        .true;
     });
 
     it('should transfer OWNER and ownership to the given address', async () => {

--- a/test/services/utils.ts
+++ b/test/services/utils.ts
@@ -8,6 +8,7 @@ import {
   RIFGateway,
   ServiceTypeManager,
   GatewayAccessControl,
+  FeeManager,
 } from 'typechain-types';
 import { deployContract } from 'utils/deployment.utils';
 

--- a/test/services/utils.ts
+++ b/test/services/utils.ts
@@ -4,12 +4,19 @@ import {
   BORROW_SERVICE_INTERFACEID,
   LENDING_SERVICE_INTERFACEID,
 } from 'test/utils/interfaceIDs';
-import { RIFGateway, ServiceTypeManager } from 'typechain-types';
+import {
+  RIFGateway,
+  ServiceTypeManager,
+  GatewayAccessControl,
+} from 'typechain-types';
 import { deployContract } from 'utils/deployment.utils';
 
 export const deployRIFGateway = async (registerInterfaceId = true) => {
   const { contract: serviceTypeManager } =
     await deployContract<ServiceTypeManager>('ServiceTypeManager', {});
+
+  const { contract: gatewayAccessControl } =
+    await deployContract<GatewayAccessControl>('GatewayAccessControl', {});
 
   if (registerInterfaceId) {
     // allow lending service interface id
@@ -29,6 +36,7 @@ export const deployRIFGateway = async (registerInterfaceId = true) => {
     'RIFGateway',
     {
       ServiceTypeManager: serviceTypeManager.address,
+      GatewayAccessControl: gatewayAccessControl.address,
     }
   );
 
@@ -37,7 +45,7 @@ export const deployRIFGateway = async (registerInterfaceId = true) => {
     await RIFGateway.feeManager()
   );
 
-  return { RIFGateway, feeManager, serviceTypeManager };
+  return { RIFGateway, feeManager, serviceTypeManager, gatewayAccessControl };
 };
 
 export function toSmallNumber(bn: BigNumber, divisor = 1e18) {


### PR DESCRIPTION
Attends to PR[ #84](https://github.com/rsksmart/rif-everyday-gateway/pull/84), last [comment](https://github.com/rsksmart/rif-everyday-gateway/pull/84#discussion_r1098858934).

Now the FeeManager and RIFGateway are not an GatewayAccessControl, instead RIFGateway receives the address of a Gateway access control and stores it in `_accessControl` and FeeManager has a getter and setter for `_rifGateway` address   that allows FeeManager to access RIFGateway's `_accessControl`, thus there is only one contract in charge of the roles.